### PR TITLE
Add CAE TensorFlow pseudocode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@
 - 数据准备与预处理。
 - cAE 模型的搭建与训练方法。
 - 生成并评估 BNS 波形的示例代码。
+- 基于 TensorFlow 的 CAE 生成雙中自習波形的伪代码（参见 cae_tensorflow_pseudocode.md）。
 
 欢迎根据需要扩展本仓库并贡献改进。

--- a/cae_tensorflow_pseudocode.md
+++ b/cae_tensorflow_pseudocode.md
@@ -1,0 +1,38 @@
+# 基于 TensorFlow 的 CAE 生成雙中自習波形（伪代码）
+
+以下内容展示了如何在 TensorFlow 中搭建卷积自编码器（Convolutional AutoEncoder，CAE）以生成 "雙中自習" 波形的伪代码示例。代码只给出结构和关键步骤，实际实现时需根据具体数据和任务进行调整。
+
+```
+# 1. 导入依赖
+import tensorflow as tf
+from tensorflow.keras import layers, models
+
+# 2. 构建编码器
+inputs = layers.Input(shape=(波形长度, 1))  # 波形为一维序列
+x = layers.Conv1D(16, kernel_size=3, activation='relu', padding='same')(inputs)
+x = layers.MaxPooling1D(pool_size=2, padding='same')(x)
+x = layers.Conv1D(8, kernel_size=3, activation='relu', padding='same')(x)
+encoded = layers.MaxPooling1D(pool_size=2, padding='same')(x)
+
+# 3. 构建解码器
+x = layers.Conv1D(8, kernel_size=3, activation='relu', padding='same')(encoded)
+x = layers.UpSampling1D(size=2)(x)
+x = layers.Conv1D(16, kernel_size=3, activation='relu', padding='same')(x)
+x = layers.UpSampling1D(size=2)(x)
+decoded = layers.Conv1D(1, kernel_size=3, activation='sigmoid', padding='same')(x)
+
+# 4. 组装模型
+cae = models.Model(inputs, decoded)
+cae.compile(optimizer='adam', loss='mse')
+
+# 5. 训练模型
+cae.fit(训练波形, 训练波形,
+                epochs=若干轮次,
+                batch_size=批大小,
+                validation_data=(验证波形, 验证波形))
+
+# 6. 使用训练好的模型生成波形
+生成波形 = cae.predict(输入噪声或其他条件信号)
+```
+
+上述伪代码提供了基本的层次结构和训练流程，实际应用中可以根据波形的特性、数据规模以及任务需求，增加或调整卷积层数、卷积核大小、激活函数等超参数。


### PR DESCRIPTION
## Summary
- add a TensorFlow-based CAE pseudocode example
- mention the new pseudocode file in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fdf2080f4832e87b72ff84e27a4da